### PR TITLE
adding code for removing copyright changes

### DIFF
--- a/vector_index/generate_vector_db.py
+++ b/vector_index/generate_vector_db.py
@@ -2,6 +2,7 @@ import os
 import hashlib
 import pickle
 import time
+import re
 from pathlib import Path
 
 from llama_index.core import (
@@ -106,6 +107,8 @@ class KnowledgeBase:
 
         nodes = []
         for doc in docs:
+            cleaned_text = re.sub(r"(?s)^\s*/\*+.*?\*/\s*", "", doc.text, count=1)
+            doc.set_content(cleaned_text)
             if doc.metadata.get("file_name", "").endswith(".py"):
                 parser = CodeHierarchyNodeParser(
                     language="python",

--- a/vector_index/generate_vector_db.py
+++ b/vector_index/generate_vector_db.py
@@ -107,19 +107,21 @@ class KnowledgeBase:
 
         nodes = []
         for doc in docs:
-            cleaned_text = re.sub(r"(?s)^\s*/\*+.*?\*/\s*", "", doc.text, count=1)
-            doc.set_content(cleaned_text)
             if doc.metadata.get("file_name", "").endswith(".py"):
                 parser = CodeHierarchyNodeParser(
                     language="python",
                     code_splitter=CodeSplitter(language="python", chunk_lines=1000, max_chars=2000)
                 )
             elif doc.metadata.get("file_name", "").endswith(".cpp"):
+                cleaned_text = re.sub(r"(?s)^\s*/\*+.*?\*/\s*", "", doc.text, count=1)
+                doc.set_content(cleaned_text)
                 parser = CodeHierarchyNodeParser(
                     language="cpp",
                     code_splitter=CodeSplitter(language="cpp", chunk_lines=30, max_chars=2000)
                 )
             elif doc.metadata.get("file_name", "").endswith(".c"):
+                cleaned_text = re.sub(r"(?s)^\s*/\*+.*?\*/\s*", "", doc.text, count=1)
+                doc.set_content(cleaned_text)
                 parser = CodeHierarchyNodeParser(
                     language="c",
                     code_splitter=CodeSplitter(language="c", chunk_lines=30, max_chars=2000)


### PR DESCRIPTION
The tested example for this is

```bash
(Pdb) p(doc.text)
'/***************************************************************************************************\n * Copyright (c) 2024 - 2025 Codeplay Software Ltd. All rights reserved.\n * SPDX-License-Identifier: BSD-3-Clause\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions are met:\n *\n * 1. Redistributions of source code must retain the above copyright notice, this\n * list of conditions and the following disclaimer.\n *\n * 2. Redistributions in binary form must reproduce the above copyright notice,\n * this list of conditions and the following disclaimer in the documentation\n * and/or other materials provided with the distribution.\n *\n * 3. Neither the name of the copyright holder nor the names of its\n * contributors may be used to endorse or promote products derived from\n * this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"\n * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\n * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\n * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\n * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\n * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\n * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n *\n **************************************************************************************************/\n/*! \\file\n    \\brief Tests for device-wide Flash Attention Decode interface\n*/\n\n#pragma once\n\n#include "cutlass/epilogue/collective/default_epilogue.hpp"\n#include "cutlass/gemm/device/gemm_universal_adapter.h"\n#include "flash_attention_v2/collective/fmha_fusion.hpp"\n#include "flash_attention_v2/kernel/tile_scheduler.hpp"\n#include "cutlass/util/packed_stride.hpp"\n#include "flash_attention_v2/kernel/xe_flash_attn_decode.hpp"\n#include "flash_attention_v2/collective/xe_flash_attn_decode_epilogue.hpp"\n#include "flash_attention_v2/collective/xe_flash_attn_decode_softmax_epilogue.hpp"\n#include "cutlass/util/GPU_Clock.hpp"\n#include "cutlass/util/sycl_event_manager.hpp"\n\n#include <cute/tensor.hpp>\n#include <random>\n\n#include "cutlass/util/command_line.h"\n#include "cutlass/util/device_memory.h"\n#include "cutlass/util/reference/device/gemm_complex.h"\n#include "cutlass/util/reference/device/tensor_compare.h"\n#include "cutlass/util/device_memory.h"\n#include "cutlass/util/reference/device/sycl_tensor_fill.h"\n\n#include "../gemm/device/testbed_utils.h"\n#include "../common/cutlass_unit_test.h"\n\nnamespace test {\nnamespace flash_attention {\n\nusing namespace cute;\n\nusing MMAOperationBF16 = XE_1x16x16_F32BF16BF16F32_TT;\nusing MMAOperationFP16 = XE_1x16x16_F32F16F16F32_TT;\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h64 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _64, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h96 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _96, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h128 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _128, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h192 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _192, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\nusing GmemTiledCopyQU16 = cute::XE_2D_U16x1x16_LD_N;\nusing GmemTiledCopyKU16 = cute::XE_2D_U16x16x16_LD_T;\nusing GmemTiledCopyVU16 = cute::XE_2D_U16x32x32_LD_V;\nusing GmemTiledCopyStoreU32 = cute::XE_2D_U32x1x16_ST_N;\nusing GmemTiledCopyStoreU16 = cute::XE_2D_U16x1x16_ST_N;\n\ntemplate<typename ElementInputType, typename ElementAccumulatorType, typename ElementOutputType,  \n         typename TileShapeQK, typename TileShapePV, typename TileShapeOutput, typename SubgroupLayout, \n         typename MMAOperation, bool HasCausalMask, bool isVarLen, typename TiledCopyQ, typename TiledCopyK,\n         typename TiledCopyV, typename TiledCopyStore, bool PagedKV>\nstruct XE_Flash_Attention_Decode {\n  using LayoutQ = cutlass::layout::RowMajor;\n  using LayoutK = cutlass::layout::ColumnMajor;\n  using LayoutV = cutlass::layout::RowMajor;\n  using LayoutO = cutlass::layout::RowMajor;\n\n  using ElementAccumulator = ElementAccumulatorType;\n  using ElementComputeEpilogue = ElementAccumulatorType;\n  using ElementInputQ = ElementInputType;\n  using ElementInputKV = ElementInputType;\n  using ElementOutput = ElementOutputType;\n\n  using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int, int>;\n  using ProblemShapeVarlen = cute::tuple<int, int, int, cutlass::fmha::collective::VariableLength,\n'
(Pdb) n
> /home/rajprinc/ValGenAgent/vector_index/generate_vector_db.py(112)parse_documents_by_type()
-> doc.set_content(cleaned_text)
(Pdb) n
> /home/rajprinc/ValGenAgent/vector_index/generate_vector_db.py(113)parse_documents_by_type()
-> if doc.metadata.get("file_name", "").endswith(".py"):
(Pdb) p(doc.text)
'/*! \\file\n    \\brief Tests for device-wide Flash Attention Decode interface\n*/\n\n#pragma once\n\n#include "cutlass/epilogue/collective/default_epilogue.hpp"\n#include "cutlass/gemm/device/gemm_universal_adapter.h"\n#include "flash_attention_v2/collective/fmha_fusion.hpp"\n#include "flash_attention_v2/kernel/tile_scheduler.hpp"\n#include "cutlass/util/packed_stride.hpp"\n#include "flash_attention_v2/kernel/xe_flash_attn_decode.hpp"\n#include "flash_attention_v2/collective/xe_flash_attn_decode_epilogue.hpp"\n#include "flash_attention_v2/collective/xe_flash_attn_decode_softmax_epilogue.hpp"\n#include "cutlass/util/GPU_Clock.hpp"\n#include "cutlass/util/sycl_event_manager.hpp"\n\n#include <cute/tensor.hpp>\n#include <random>\n\n#include "cutlass/util/command_line.h"\n#include "cutlass/util/device_memory.h"\n#include "cutlass/util/reference/device/gemm_complex.h"\n#include "cutlass/util/reference/device/tensor_compare.h"\n#include "cutlass/util/device_memory.h"\n#include "cutlass/util/reference/device/sycl_tensor_fill.h"\n\n#include "../gemm/device/testbed_utils.h"\n#include "../common/cutlass_unit_test.h"\n\nnamespace test {\nnamespace flash_attention {\n\nusing namespace cute;\n\nusing MMAOperationBF16 = XE_1x16x16_F32BF16BF16F32_TT;\nusing MMAOperationFP16 = XE_1x16x16_F32F16F16F32_TT;\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h64 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _64, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h96 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _96, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h128 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _128, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\ntemplate <int KVTile, int NumSGs>\nstruct Shape_h192 {\n  using ShapeQK = Shape<_1, Int<KVTile>, _64>;\n  using ShapePV = Shape<_1, _32, Int<KVTile>>;\n  using ShapeOutput = Shape<_1, _192, Int<KVTile>>;\n  using SubgroupLayout = Layout<Shape<Int<NumSGs>, _1, _1>>;\n};\n\nusing GmemTiledCopyQU16 = cute::XE_2D_U16x1x16_LD_N;\nusing GmemTiledCopyKU16 = cute::XE_2D_U16x16x16_LD_T;\nusing GmemTiledCopyVU16 = cute::XE_2D_U16x32x32_LD_V;\nusing GmemTiledCopyStoreU32 = cute::XE_2D_U32x1x16_ST_N;\nusing GmemTiledCopyStoreU16 = cute::XE_2D_U16x1x16_ST_N;\n\ntemplate<typename ElementInputType, typename ElementAccumulatorType, typename ElementOutputType,  \n         typename TileShapeQK, typename TileShapePV, typename TileShapeOutput, typename SubgroupLayout, \n         typename MMAOperation, bool HasCausalMask, bool isVarLen, typename TiledCopyQ, typename TiledCopyK,\n         typename TiledCopyV, typename TiledCopyStore, bool PagedKV>\nstruct XE_Flash_Attention_Decode {\n  using LayoutQ = cutlass::layout::RowMajor;\n  using LayoutK = cutlass::layout::ColumnMajor;\n  using LayoutV = cutlass::layout::RowMajor;\n  using LayoutO = cutlass::layout::RowMajor;\n\n  using ElementAccumulator = ElementAccumulatorType;\n  using ElementComputeEpilogue = ElementAccumulatorType;\n  using ElementInputQ = ElementInputType;\n  using ElementInputKV = ElementInputType;\n  using ElementOutput = ElementOutputType;\n\n  using ProblemShapeRegular = cute::tuple<int, int, int, int, int, int, int, int>;\n  using ProblemShapeVarlen = cute::tuple<int, int, int, cutlass::fmha::collective::VariableLength,\n                                         cutlass::fmha::collective::VariableLength, cutlass::fmha::collective::VariableLength,\n                                         int, int>;\n  using ProblemShapeType = std::conditional_t<isVarLen, ProblemShapeVarlen, ProblemShapeRegular>;\n\n  static constexpr int PipelineStages = 2;\n  using bltest\n\n/////////////////////////////////////////////////////////////////////////////////////////////////\n'
(Pdb) 